### PR TITLE
ensure confirmation is above page icon

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -358,6 +358,7 @@ label.text-div input[type="checkbox"]:focus + .checkbox-wrapper {
     font-family: 'Titillium Web';
     font-size: 20px;
     padding: 20px;
+    z-index: 10;
   }
 
   #confirmation.show {


### PR DESCRIPTION
Noticed a z-index thing where page icons overlap the confirmation thingy at certain widths.

